### PR TITLE
Add multi-process locking

### DIFF
--- a/filecache/__init__.py
+++ b/filecache/__init__.py
@@ -106,11 +106,7 @@ class FileCache:
             raise ValueError('shared argument has directory elements')
 
         self._cache_dir = temp_dir / sub_dir
-
-        try:
-            self._cache_dir.mkdir(exist_ok=self._is_shared)
-        except (FileNotFoundError, FileExistsError, ValueError):  # pragma: no cover
-            raise
+        self._cache_dir.mkdir(exist_ok=self._is_shared)
 
         self._is_cache_owner = cache_owner
         self._is_mp_safe = mp_safe if mp_safe is not None else self._is_shared
@@ -227,8 +223,8 @@ class FileCache:
                 for name in dirs:
                     os.rmdir(os.path.join(root, name))
 
+        print('Removing', str(self._cache_dir))
         try:
-            print('Removing', str(self._cache_dir))
             self._cache_dir.rmdir()
         except FileNotFoundError:  # pragma: no cover
             pass
@@ -445,8 +441,7 @@ class FileCacheSource:
         try:
             with open(temp_local_path, 'wb') as f:
                 for chunk in response.iter_content(chunk_size=1024*1024):
-                    if chunk:  # pragma: no cover
-                        f.write(chunk)
+                    f.write(chunk)
             temp_local_path.rename(local_path)
         except Exception:  # pragma: no cover
             temp_local_path.unlink(missing_ok=True)

--- a/filecache/__init__.py
+++ b/filecache/__init__.py
@@ -414,7 +414,7 @@ class FileCacheSource:
     def _unprotected_retrieve(self, filename, local_path):
         if local_path.exists():
             if (self._filecache.is_shared or
-                self._filecache._is_cached(local_path)):  # pragma: no cover
+                    self._filecache._is_cached(local_path)):  # pragma: no cover
                 return local_path
             raise FileExistsError(
                 f'Internal error - File already exists: {filename}')  # pragma: no cover

--- a/filecache/__init__.py
+++ b/filecache/__init__.py
@@ -409,7 +409,10 @@ class FileCacheSource:
                 # to do it in this order because otherwise it won't work on Windows,
                 # where locks are not just advisory.
                 lock.release()
-                lock_path.unlink()
+                try:
+                    lock_path.unlink()
+                except FileNotFoundError:
+                    pass
 
         return self._unprotected_retrieve(filename, local_path)
 

--- a/filecache/__init__.py
+++ b/filecache/__init__.py
@@ -445,7 +445,7 @@ class FileCacheSource:
                     if chunk:
                         f.write(chunk)
             temp_local_path.rename(local_path)
-        except:
+        except Exception:
             temp_local_path.unlink(missing_ok=True)
             raise
 
@@ -469,7 +469,7 @@ class FileCacheSource:
             raise FileNotFoundError(
                 f'Failed to download file from: gs://{self._gs_bucket_name}/'
                 f'{blob_name}')
-        except:
+        except Exception:
             temp_local_path.unlink(missing_ok=True)
             raise
 
@@ -481,14 +481,15 @@ class FileCacheSource:
 
         temp_local_path = local_path.with_suffix(local_path.suffix + '.dltemp')
         try:
-            self._s3_client.download_file(self._s3_bucket_name, s3_key, str(temp_local_path))
+            self._s3_client.download_file(self._s3_bucket_name, s3_key,
+                                          str(temp_local_path))
             temp_local_path.rename(local_path)
         except botocore.exceptions.ClientError:
             temp_local_path.unlink(missing_ok=True)
             raise FileNotFoundError(
                 f'Failed to download file from: s3://{self._s3_bucket_name}/'
                 f'{s3_key}')
-        except:
+        except Exception:
             temp_local_path.unlink(missing_ok=True)
             raise
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 boto3
 coverage
+filelock
 flake8
 google-cloud-storage
 myst-parser

--- a/tests/test_filecache.py
+++ b/tests/test_filecache.py
@@ -404,23 +404,34 @@ def test_double_delete():
         for filename in EXPECTED_FILENAMES:
             src.retrieve(filename)
         fc.clean_up()  # Test double clean_up
+        assert not fc.cache_dir.exists()
         fc.clean_up()
+        assert not fc.cache_dir.exists()
         for filename in EXPECTED_FILENAMES:
             src.retrieve(filename)
+        assert fc.cache_dir.exists()
         fc.clean_up()
+        assert not fc.cache_dir.exists()
         fc.clean_up()
+        assert not fc.cache_dir.exists()
 
     with FileCache(shared=True) as fc:
         src = fc.new_source(HTTP_TEST_ROOT)
         for filename in EXPECTED_FILENAMES:
             src.retrieve(filename)
         fc.clean_up()  # Test double clean_up
+        assert fc.cache_dir.exists()
         fc.clean_up()
+        assert fc.cache_dir.exists()
         for filename in EXPECTED_FILENAMES:
             src.retrieve(filename)
+        assert fc.cache_dir.exists()
         fc.clean_up()
+        assert fc.cache_dir.exists()
         fc.clean_up()
+        assert fc.cache_dir.exists()
         fc.clean_up(final=True)
+        assert not fc.cache_dir.exists()
 
 
 def test_open_context():

--- a/tests/test_filecache.py
+++ b/tests/test_filecache.py
@@ -409,7 +409,7 @@ def test_open_context():
         src = fc.new_source(HTTP_TEST_ROOT)
         with src.open(EXPECTED_FILENAMES[0], 'r') as fp:
             cache_data = fp.read()
-            _compare_to_expected_data(cache_data, EXPECTED_FILENAMES[0])
+        _compare_to_expected_data(cache_data, EXPECTED_FILENAMES[0])
 
 
 def test_owner():

--- a/tests/test_filecache.py
+++ b/tests/test_filecache.py
@@ -353,7 +353,10 @@ def test_locking():
         with pytest.raises(TimeoutError):
             src.retrieve(EXPECTED_FILENAMES[0])
         lock.release()
-        lock_path.unlink()
+        try:
+            lock_path.unlink()
+        except FileNotFoundError:
+            pass
     fc.clean_up(final=True)
 
     with FileCache(shared=False) as fc:
@@ -366,7 +369,10 @@ def test_locking():
         lock.acquire()
         src.retrieve(EXPECTED_FILENAMES[0])  # shared=False doesn't lock
         lock.release()
-        lock_path.unlink()
+        try:
+            lock_path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def test_bad_cache_dir():

--- a/tests/test_filecache.py
+++ b/tests/test_filecache.py
@@ -442,8 +442,8 @@ def test_open_context():
         _compare_to_expected_data(cache_data, EXPECTED_FILENAMES[0])
 
 
-def test_owner():
-    with FileCache(shared=True, owner=True) as fc1:
+def test_cache_owner():
+    with FileCache(shared=True, cache_owner=True) as fc1:
         with FileCache(shared=True) as fc2:
             pass
         assert fc1.cache_dir == fc2.cache_dir

--- a/tests/test_filecache.py
+++ b/tests/test_filecache.py
@@ -343,12 +343,12 @@ def test_multi_sources_shared(prefix):
 
 def test_locking():
     with FileCache(shared=True) as fc:
-        src = fc.new_source(HTTP_TEST_ROOT, lock_timeout=1)
+        src = fc.new_source(HTTP_TEST_ROOT, lock_timeout=0)
         filename = (HTTP_TEST_ROOT.replace('https://', 'http_') + '/' +
                     EXPECTED_FILENAMES[0])
         local_path = fc.cache_dir / filename
         lock_path = src._lock_path(local_path)
-        lock = filelock.FileLock(lock_path, timeout=1)
+        lock = filelock.FileLock(lock_path, timeout=0)
         lock.acquire()
         with pytest.raises(TimeoutError):
             src.retrieve(EXPECTED_FILENAMES[0])
@@ -357,12 +357,12 @@ def test_locking():
     fc.clean_up(final=True)
 
     with FileCache(shared=False) as fc:
-        src = fc.new_source(HTTP_TEST_ROOT, lock_timeout=1)
+        src = fc.new_source(HTTP_TEST_ROOT, lock_timeout=0)
         filename = (HTTP_TEST_ROOT.replace('https://', 'http_') + '/' +
                     EXPECTED_FILENAMES[0])
         local_path = fc.cache_dir / filename
         lock_path = src._lock_path(local_path)
-        lock = filelock.FileLock(lock_path, timeout=1)
+        lock = filelock.FileLock(lock_path, timeout=0)
         lock.acquire()
         src.retrieve(EXPECTED_FILENAMES[0])  # shared=False doesn't lock
         lock.release()


### PR DESCRIPTION
# Fixed Issues

None.

# Summary of Changes

- Make `FileCache` a context manager.
- Add file locking to prevent multiple processes from trying to download the same file simultaneously.
- Add the `mp_safe` flag to allow turning off locking.
- Add more paranoia to deleting the cache directory, including the `exception_if_missing` flag to raise an exception if we try to delete a file during cleanup that should be there but isn't.
- Add the `cache_owner` flag to allowed automatic cleanup of a shared cache.
- Use streaming downloads for HTTP to save memory for large files.
- Make all download operations atomic by downloading into a temporary file first.
- Add `open` context manager to `FileCacheSource` that downloads and opens the file and closes after the context exits.
- Refactor and clean up code and documentation.
- Add tests and keep at 100% code coverage.

# Known Problems

None.

 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances the FileCache library with multi-process safety features, improved file operations, and exception handling. It introduces file locking mechanisms, implements streaming for large file downloads, and refactors the FileCache class. The changes also include optimizing directory creation, adding debug logging, and streamlining file writing logic. These modifications aim to improve overall performance, reliability, and security of the FileCache system.
<br>
<br>
<b>Code change type</b>: Feature Addition, Security, Refactoring, Performance Improvement, Optimization, Bug Fix, Error Handling, Tests, Code Structure
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 5
</div>