### PR TITLE
Add FCPath as valid input for new_path

### DIFF
--- a/filecache/file_cache.py
+++ b/filecache/file_cache.py
@@ -1311,7 +1311,7 @@ class FileCache:
             self.upload(url, anonymous=anonymous, url_to_path=url_to_path)
 
     def new_path(self,
-                 path: str,
+                 path: str | Path | FCPath,
                  *,
                  anonymous: Optional[bool] = None,
                  lock_timeout: Optional[int] = None,
@@ -1358,10 +1358,10 @@ class FileCache:
                 If None, use the default translators for this :class:`FileCache` instance.
         """
 
-        if isinstance(path, Path):
+        if isinstance(path, (Path, FCPath)):
             path = str(path)
         if not isinstance(path, str):
-            raise TypeError('path is not a str or Path')
+            raise TypeError('path is not a str or Path or FCPath')
         path = path.replace('\\', '/').rstrip('/')
         if anonymous is None:
             anonymous = self.anonymous


### PR DESCRIPTION
# Fixed Issues

- N/A

# Summary of Changes

- Add `FCPath` as a valid input for `FileCache.new_path`.

# Known Problems

- None
 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the FileCache class by improving path handling capabilities. The new_path method now accepts FCPath objects as input, in addition to str and Path types. This change increases the flexibility of the FileCache API, allowing users to work directly with FCPath objects.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>