### PR TITLE
Remove expanduser() and resolve, add py.typed

### DIFF
--- a/filecache/file_cache.py
+++ b/filecache/file_cache.py
@@ -1311,7 +1311,7 @@ class FileCache:
             self.upload(url, anonymous=anonymous, url_to_path=url_to_path)
 
     def new_path(self,
-                 path: str,
+                 path: str | Path | FCPath,
                  *,
                  anonymous: Optional[bool] = None,
                  lock_timeout: Optional[int] = None,
@@ -1358,10 +1358,10 @@ class FileCache:
                 If None, use the default translators for this :class:`FileCache` instance.
         """
 
-        if isinstance(path, Path):
+        if isinstance(path, (Path, FCPath)):
             path = str(path)
         if not isinstance(path, str):
-            raise TypeError('path is not a str or Path')
+            raise TypeError('path is not a str or Path or FCPath')
         path = path.replace('\\', '/').rstrip('/')
         if anonymous is None:
             anonymous = self.anonymous

--- a/filecache/file_cache.py
+++ b/filecache/file_cache.py
@@ -349,7 +349,7 @@ class FileCache:
                     # file:///dir/file
                     # We have to add the / back on the beginning
                     sub_path = f'/{sub_path}'
-                sub_path = str(Path(sub_path).expanduser().resolve())
+                sub_path = str(Path(sub_path))
             if scheme not in _SCHEME_CLASSES:
                 raise ValueError(f'Unknown scheme {scheme} in {url}')
             return scheme, remote, sub_path
@@ -362,7 +362,7 @@ class FileCache:
                              cache_dir: Path,
                              cache_subdir: str) -> Path:
         if scheme == 'file':
-            return Path(path).expanduser().resolve()
+            return Path(path)
         return cache_dir / cache_subdir / path
 
     def _get_source_and_paths(self,

--- a/filecache/file_cache_source.py
+++ b/filecache/file_cache_source.py
@@ -333,7 +333,7 @@ class FileCacheSourceFile(FileCacheSource):
             file.
         """
 
-        local_path_p = Path(local_path).expanduser().resolve()
+        local_path_p = Path(local_path)
 
         if not local_path_p.is_file():
             raise FileNotFoundError(f'File does not exist: {local_path_p}')
@@ -360,7 +360,7 @@ class FileCacheSourceFile(FileCacheSource):
             FileNotFoundError: If the file does not exist.
         """
 
-        local_path_p = Path(local_path).expanduser().resolve()
+        local_path_p = Path(local_path)
 
         if not local_path_p.is_file():
             raise FileNotFoundError(f'File does not exist: {local_path_p}')
@@ -452,7 +452,7 @@ class FileCacheSourceHTTP(FileCacheSource):
             The download is an atomic operation.
         """
 
-        local_path = Path(local_path).expanduser().resolve()
+        local_path = Path(local_path)
 
         url = self._src_prefix_ + sub_path
 
@@ -568,7 +568,7 @@ class FileCacheSourceGS(FileCacheSource):
             The download is an atomic operation.
         """
 
-        local_path = Path(local_path).expanduser().resolve()
+        local_path = Path(local_path)
 
         local_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -608,7 +608,7 @@ class FileCacheSourceGS(FileCacheSource):
             FileNotFoundError: If the local file does not exist.
         """
 
-        local_path = Path(local_path).expanduser().resolve()
+        local_path = Path(local_path)
 
         if not local_path.exists():
             raise FileNotFoundError(f'File does not exist: {local_path}')
@@ -709,7 +709,7 @@ class FileCacheSourceS3(FileCacheSource):
             The download is an atomic operation.
         """
 
-        local_path = Path(local_path).expanduser().resolve()
+        local_path = Path(local_path)
 
         local_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -745,7 +745,7 @@ class FileCacheSourceS3(FileCacheSource):
             FileNotFoundError: If the local file does not exist.
         """
 
-        local_path = Path(local_path).expanduser().resolve()
+        local_path = Path(local_path)
 
         self._client.upload_file(str(local_path), self._bucket_name, sub_path)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ Issues = "https://github.com/SETI/rms-filecache/issues"
 [tool.setuptools]
 packages = ["filecache"]
 
+[tool.setuptools.package-data]
+"pkgname" = ["py.typed"]
+
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
 write_to = "filecache/_version.py"

--- a/tests/test_file_cache.py
+++ b/tests/test_file_cache.py
@@ -220,7 +220,7 @@ def test_easy_logger(capsys):
     with FileCache(cache_name=None) as fc:
         fc.get_local_path(f'{WINDOWS_PREFIX}/')
     if WINDOWS_PREFIX:
-        assert 'Returning local path for c:/ as C:\\\n' in capsys.readouterr().out
+        assert 'Returning local path for c:/ as c:\\\n' in capsys.readouterr().out
     else:
         assert 'Returning local path for / as /\n' in capsys.readouterr().out
     filecache.set_global_logger(None)


### PR DESCRIPTION
# Fixed Issues

- N/A

# Summary of Changes

- `Path.expanduser` and `Path.resolve` turn out to be very slow operations, and `filecache` was using them extensively. I have removed all uses for performance. Frankly no one should be including `~name` in a path anyway.
- Add `py.typed` marker and added to `pyproject.toml` for packaging.

# Known Problems

- None.

 
 <div id='description'>
<h3>Summary by Bito</h3>
Performance optimization PR removing Path operations (expanduser and resolve) from file_cache.py and file_cache_source.py. Adds py.typed marker in pyproject.toml for improved type checking support. Introduces FCPath as an acceptable path type. However, removal of path operations may cause functionality issues with home directory references and symbolic links.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>