### PR TITLE
Fix with_suffix problem

### DIFF
--- a/filecache/file_cache_source.py
+++ b/filecache/file_cache_source.py
@@ -608,7 +608,7 @@ class FileCacheSourceHTTP(FileCacheSource):
         except requests.exceptions.RequestException as e:
             raise FileNotFoundError(f'Failed to download file: {url}') from e
 
-        temp_local_path = local_path.with_suffix(f'{local_path.suffix}.{uuid.uuid4()}')
+        temp_local_path = local_path.with_suffix(f'.{local_path.suffix}_{uuid.uuid4()}')
         try:
             with open(temp_local_path, 'wb') as f:
                 for chunk in response.iter_content(chunk_size=1024*1024):
@@ -760,7 +760,7 @@ class FileCacheSourceGS(FileCacheSource):
 
         blob = self._bucket.blob(sub_path)
 
-        temp_local_path = local_path.with_suffix(f'{local_path.suffix}.{uuid.uuid4()}')
+        temp_local_path = local_path.with_suffix(f'.{local_path.suffix}_{uuid.uuid4()}')
         try:
             blob.download_to_filename(str(temp_local_path))
             temp_local_path.rename(local_path)
@@ -965,7 +965,7 @@ class FileCacheSourceS3(FileCacheSource):
 
         local_path.parent.mkdir(parents=True, exist_ok=True)
 
-        temp_local_path = local_path.with_suffix(f'{local_path.suffix}.{uuid.uuid4()}')
+        temp_local_path = local_path.with_suffix(f'.{local_path.suffix}_{uuid.uuid4()}')
         try:
             self._client.download_file(self._bucket_name, sub_path,
                                        str(temp_local_path))
@@ -1193,7 +1193,7 @@ class FileCacheSourceFake(FileCacheSource):
 
         local_path.parent.mkdir(parents=True, exist_ok=True)
 
-        temp_local_path = local_path.with_suffix(f'{local_path.suffix}.{uuid.uuid4()}')
+        temp_local_path = local_path.with_suffix(f'.{local_path.suffix}_{uuid.uuid4()}')
         try:
             shutil.copy2(source_path, temp_local_path)
             temp_local_path.rename(local_path)
@@ -1226,7 +1226,7 @@ class FileCacheSourceFake(FileCacheSource):
         dest_path = self._storage_dir / sub_path
         dest_path.parent.mkdir(parents=True, exist_ok=True)
 
-        temp_dest_path = dest_path.with_suffix(f'{dest_path.suffix}.{uuid.uuid4()}')
+        temp_dest_path = dest_path.with_suffix(f'.{dest_path.suffix}_{uuid.uuid4()}')
         try:
             shutil.copy2(local_path, temp_dest_path)
             temp_dest_path.rename(dest_path)

--- a/tests/test_file_cache_source.py
+++ b/tests/test_file_cache_source.py
@@ -316,7 +316,7 @@ def test_fake_source_atomic_operations(tmp_path: Path):
             assert src.exists()
             assert not dst.exists()
             # Just verify it's a temp file with a UUID-like pattern
-            assert '.txt.' in str(src)
+            assert '.txt_' in str(src)
             os.rename(str(src), str(dst))  # Use os.rename to avoid recursion
 
         original_rename = pathlib.Path.rename
@@ -335,7 +335,7 @@ def test_fake_source_atomic_operations(tmp_path: Path):
             assert src.exists()
             assert not dst.exists()
             # Just verify it's a temp file with a UUID-like pattern
-            assert '.txt.' in str(src)
+            assert '.txt_' in str(src)
             os.rename(str(src), str(dst))  # Use os.rename to avoid recursion
 
         pathlib.Path.rename = mock_rename2


### PR DESCRIPTION
# Fixed Issues

N/A

# Summary of Changes

- Fixes problem with `with_suffix` requiring a suffix starting with `.`

# Known Problems

- None
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes issues with the with_suffix method in filecache/file_cache_source.py by ensuring proper suffix formatting with a leading dot and UUID separator. The changes improve temporary file path generation across the filecache module, creating a more robust approach to file naming during download and copy operations.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>