### PR TITLE
Add __str__ and __repr__ to all public classes (fixes #21)

### DIFF
--- a/filecache/file_cache.py
+++ b/filecache/file_cache.py
@@ -324,6 +324,14 @@ class FileCache:
 
         atexit.register(self._maybe_delete_cache)
 
+    def __str__(self) -> str:
+        """Return the cache directory path as the string representation."""
+        return str(self._cache_dir)
+
+    def __repr__(self) -> str:
+        """Return a string showing the class name and cache directory."""
+        return f'FileCache({self._cache_dir!r})'
+
     def _validate_nthreads(self,
                            nthreads: Optional[int]) -> int:
         if nthreads is not None and (not isinstance(nthreads, int) or nthreads <= 0):

--- a/filecache/file_cache_source.py
+++ b/filecache/file_cache_source.py
@@ -72,6 +72,15 @@ class FileCacheSource(ABC):
         # The _cache_subdir attribute is only used by the FileCache class
         self._cache_subdir = ''
 
+    def __str__(self) -> str:
+        """Return the source URL prefix (e.g. gs://bucket)."""
+        return self._src_prefix
+
+    def __repr__(self) -> str:
+        """Return a string showing the class name, source prefix, and anonymous flag."""
+        return (f'{type(self).__name__}({self._src_prefix!r}, '
+                f'anonymous={self._anonymous!r})')
+
     @classmethod
     @abstractmethod
     def schemes(self) -> tuple[str, ...]:
@@ -1786,6 +1795,13 @@ class FileCacheSourceFake(FileCacheSource):
         self._storage_dir = self._storage_base / remote
         self._storage_dir.mkdir(parents=True, exist_ok=True)
         self._cache_subdir = self._src_prefix.replace('fake://', 'fake_')
+
+    def __repr__(self) -> str:
+        """Return class name, source prefix, and storage directory."""
+        return (
+            f'{type(self).__name__}({self._src_prefix!r}, anonymous={self._anonymous!r}, '
+            f'storage_dir={self._storage_base!r})'
+        )
 
     @classmethod
     def schemes(cls) -> tuple[str, ...]:

--- a/tests/test_file_cache.py
+++ b/tests/test_file_cache.py
@@ -353,6 +353,23 @@ def test_cache_name_named():
     assert not fc4.cache_dir.exists()
 
 
+def test_filecache_str_repr():
+    """Test FileCache __str__ and __repr__ (issue #21)."""
+    with FileCache(cache_name=None) as fc:
+        assert str(fc) == str(fc.cache_dir)
+        r = repr(fc)
+        assert r.startswith('FileCache(')
+        assert r.endswith(')')
+        assert str(fc.cache_dir) in r
+    fc2 = FileCache(cache_name='repr_test')
+    try:
+        assert str(fc2) == str(fc2.cache_dir)
+        assert 'FileCache(' in repr(fc2)
+        assert '_filecache_repr_test' in repr(fc2) or str(fc2.cache_dir) in repr(fc2)
+    finally:
+        fc2.delete_cache()
+
+
 def test_cache_name_bad():
     with pytest.raises(TypeError):
         FileCache(cache_name=5)

--- a/tests/test_file_cache_source.py
+++ b/tests/test_file_cache_source.py
@@ -63,6 +63,35 @@ def test_filesource_good():
     assert sl.exists(EXPECTED_DIR / EXPECTED_FILENAMES[1])
 
 
+def test_source_str_repr():
+    """Test FileCacheSource subclasses __str__ and __repr__ (issue #21)."""
+    sl = FileCacheSourceFile('file', '')
+    assert str(sl) == 'file://'
+    assert repr(sl) == "FileCacheSourceFile('file://', anonymous=False)"
+
+    http_src = FileCacheSourceHTTP('https', 'example.com')
+    assert str(http_src) == 'https://example.com'
+    assert repr(http_src) == "FileCacheSourceHTTP('https://example.com', anonymous=False)"
+
+    gs_src = FileCacheSourceGS('gs', 'my-bucket', anonymous=True)
+    assert str(gs_src) == 'gs://my-bucket'
+    assert repr(gs_src) == "FileCacheSourceGS('gs://my-bucket', anonymous=True)"
+
+    s3_src = FileCacheSourceS3('s3', 'my-bucket', anonymous=True)
+    assert str(s3_src) == 's3://my-bucket'
+    assert repr(s3_src) == "FileCacheSourceS3('s3://my-bucket', anonymous=True)"
+
+
+def test_fake_source_str_repr(tmp_path: Path):
+    """Test FileCacheSourceFake __str__ and __repr__ (issue #21)."""
+    fake = FileCacheSourceFake('fake', 'test-bucket', storage_dir=tmp_path)
+    assert str(fake) == 'fake://test-bucket'
+    assert "FileCacheSourceFake('fake://test-bucket'" in repr(fake)
+    assert 'anonymous=False' in repr(fake)
+    assert 'storage_dir=' in repr(fake)
+    assert str(tmp_path) in repr(fake)
+
+
 def test_source_notimp():
     with pytest.raises(TypeError):
         FileCacheSource('', '').exists('')


### PR DESCRIPTION
## Summary

Fixes #21: Add `__str__` and `__repr__` to all public classes that did not already have them.

## Changes

### Implementation
- **FileCache** (`file_cache.py`): Added `__str__` (returns the cache directory path) and `__repr__` (returns `FileCache(<cache_dir>)`).
- **FileCacheSource** (`file_cache_source.py`): Added `__str__` (returns the source URL prefix, e.g. `gs://bucket`) and `__repr__` (returns class name, source prefix, and `anonymous` flag). All subclasses inherit this; no need to override except where extra detail is useful.
- **FileCacheSourceFake**: Overrode `__repr__` to include `storage_dir` so the storage location is visible when debugging.
- **FCPath**: Already had `__str__` and `__repr__`; left unchanged per issue (“Update any existing __repr__ to include additional important detail if appropriate” — current repr is already clear).

### Tests
- `test_filecache_str_repr` in `test_file_cache.py`: Asserts `str(fc)` equals the cache dir and `repr(fc)` has the expected form.
- `test_source_str_repr` in `test_file_cache_source.py`: Asserts `str`/`repr` for `FileCacheSourceFile`, `FileCacheSourceHTTP`, `FileCacheSourceGS`, and `FileCacheSourceS3`.
- `test_fake_source_str_repr` in `test_file_cache_source.py`: Asserts `FileCacheSourceFake` `str`/`repr` including `storage_dir`.

### Documentation
- API docs are generated via Sphinx `automodule` with `:special-members:`, so the new `__str__` and `__repr__` methods are included in the module documentation automatically.

### Lint
- Adjusted line breaks in `file_cache_source.py` to satisfy flake8 E501 (line length ≤ 90).

## Checklist
- [x] All public classes have `__str__` and `__repr__` (or inherit them).
- [x] Tests added/updated.
- [x] Documentation reflects the new methods (via automodule).
- [x] flake8 passes; mypy status unchanged (existing stub/return-type issues only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `FileCache` objects now provide meaningful string representations, displaying the cache directory path when printed or inspected.
  * `FileCacheSource` objects now display source and configuration information in their string representations, with enhanced details for fake sources including storage directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->